### PR TITLE
add patch coordinates when saving to .h5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hest"
-version = "0.0.1"
+version = "1.1.1"
 authors = [
   { name="Paul Doucet", email="pdoucet@bwh.harvard.edu" },
   { name="Guillaume Jaume", email="gjaume@bwh.harvard.edu" },
@@ -28,7 +28,7 @@ dependencies = [
     "spatial_image >= 0.3.0",
     "datasets",
     "mygene",
-    "hestcore == 1.0.2"
+    "hestcore == 1.0.3"
 ]
 
 requires-python = ">=3.9"


### PR DESCRIPTION
Add the following new .h5 assets when dumping patches to h5:
- `coords`: indicates the (x, y) pixel coordinates of the top left corner for each patch (in the full resolution image, note that TENX99.tif is 0.2125um/px not 0.5um/px)
- `patch_size_src`: indicates the width/height of each patch before rescaling (hence at  0.2125um/px for TENX99)
- `patch_size_target`: indicates the width/height of each patch after rescaling (0.5um/px in our case)