### PR TITLE
HESTData: provide util to map ensemble ID to gene name

### DIFF
--- a/src/hest/HESTData.py
+++ b/src/hest/HESTData.py
@@ -681,6 +681,10 @@ class HESTData:
         
         return SpatialData(tables=new_table, images=images, shapes=shapes)
     
+    def ensembleID_to_gene(self):
+        ensembleID_to_gene(self, inplace=True)
+
+    
 class VisiumHESTData(HESTData): 
     def __init__(self, 
         adata: sc.AnnData, # type: ignore
@@ -1244,29 +1248,40 @@ def unify_gene_names(adata: sc.AnnData, species="human", drop=False) -> sc.AnnDa
     
     return adata
 
-def ensembleID_to_gene(st: HESTData) -> HESTData:
+def ensembleID_to_gene(st: HESTData, inplace=False, filter_na = False) -> HESTData:
     """
-    Converts ensemble gene IDs of a HESTData object using Biomart annosations
+    Converts ensemble gene IDs of a HESTData object using Biomart annotations and filter out genes with no matching Ensembl ID
     
     Args: 
         st (HESTData): HESTData object
+        inplace (bool): whenever to perform the changes in placce. Defaults to True.
+        filter_na (bool): whenever to filter genes that are not valid ensemble IDs. Defaults to False.
     
     Returns: 
         HESTData: HESTData object with gene names instead of ensemble gene IDs
     """
+    import scanpy as sc
+    if not inplace:
+        st = st.copy()
+
     import scanpy as sc
     species = st.meta['species']
     org = "hsapiens" if species == "Homo sapiens" else "mmusculus"
     
     annotations = sc.queries.biomart_annotations(org=org,attrs=['ensembl_gene_id', 'external_gene_name'], use_cache=True)
     ensembl_to_gene_name = dict(zip(annotations['ensembl_gene_id'], annotations['external_gene_name']))
-    st.adata.var['gene_name'] = st.adata.var_names.map(ensembl_to_gene_name)
-    
 
-    # Filter out genes where the conversion returned NaN       
-    st.adata.var_names = st.adata.var['gene_name'].fillna('')
+        
+    st.adata.var['gene_name'] = st.adata.var_names.map(ensembl_to_gene_name, na_action=None)
+    
+    if filter_na: 
+        st.adata.var_names = st.adata.var['gene_name'].fillna('')
+    else: 
+        st.adata.var['gene_name'] = st.adata.var['gene_name'].where(st.adata.var['gene_name'].notna(), st.adata.var_names)
+        
     valid_genes = st.adata.var['gene_name'].notna()
     st.adata = st.adata[:, valid_genes]
+
 
     return st
 

--- a/src/hest/__init__.py
+++ b/src/hest/__init__.py
@@ -3,7 +3,7 @@ __version__ = "0.0.1"
 from .utils import tiff_save, find_pixel_size_from_spot_coords, write_10X_h5, get_k_genes, SpotPacking
 from .autoalign import autoalign_visium
 from .readers import *
-from .HESTData import HESTData, read_HESTData, load_hest, iter_hest
+from .HESTData import HESTData, read_HESTData, load_hest, iter_hest, ensembleID_to_gene
 from .segmentation.cell_segmenters import segment_cellvit
 
 __all__ = [
@@ -20,5 +20,6 @@ __all__ = [
     'autoalign_visium',
     'write_10X_h5',
     'HESTData',
-    'segment_cellvit'
+    'segment_cellvit', 
+    'ensembleID_to_gene'
 ]

--- a/tests/hest_tests.py
+++ b/tests/hest_tests.py
@@ -17,6 +17,7 @@ if elapsed_time > MAX_HEST_IMPORT_S:
 
 from hest.autoalign import autoalign_visium
 from hest.readers import VisiumReader
+from hest.HESTData import ensembleID_to_gene
 from hest.utils import load_image
 
 
@@ -130,6 +131,12 @@ class TestHESTData(unittest.TestCase):
             self.sts = hest.load_hest(local_dir, id_list)
         else:
             self.sts = hest.load_hest('hest_data', id_list)
+
+
+    def test_conversion_ensembleID(self):
+        for idx, st in enumerate(self.sts):
+            with self.subTest(st_object=idx):
+                ensembleID_to_gene(st)
 
         
     def test_tissue_seg(self):


### PR DESCRIPTION
**This PR**
* Provides util to map genes encoded using the ensemble ID (common for several `Spatial Transcriptomics` samples) to the gene name 
* Addresses #70 

**To dos**

- [ ] Might want to make this bi-directional to have `ensembleID_to_gene` and `gene_to_ensembleID` 
- [ ] There is some redundancy with `get_gene_db()` which is not needed when using the `use_cache` when we query the biomart annotations. Are we good to remove this function @pauldoucet as I don't see it used anywhere? 

**Run instructions**

```python
from hest import iter_hest, ensembleID_to_gene

# three samples with ensemblIDs as var_names
id_list = ['SPA118', 'SPA117', 'SPA116']

for st in iter_hest('/home/iain/kh/ssd/hest_data/', id_list=id_list):
    
    print(any([var_name.startswith("ENSG") for var_name in st.adata.var_names]))
    print(st.adata.var_names[:5])
    
    st_updated = ensembleID_to_gene(st)
    
    print(any([var_name.startswith("ENSG") for var_name in st_updated.adata.var_names]))
    print(st_updated.adata.var_names[:5])
```

Expected output: 

```
True
Index(['ENSG00000000003', 'ENSG00000000005', 'ENSG00000000419',
       'ENSG00000000457', 'ENSG00000000460'],
      dtype='object')
False
Index(['TSPAN6', 'TNMD', 'DPM1', 'SCYL3', 'FIRRM'], dtype='object', name='gene_name')
True
Index(['ENSG00000000003', 'ENSG00000000005', 'ENSG00000000419',
       'ENSG00000000457', 'ENSG00000000460'],
      dtype='object')
False
Index(['TSPAN6', 'TNMD', 'DPM1', 'SCYL3', 'FIRRM'], dtype='object', name='gene_name')
True
Index(['ENSG00000000003', 'ENSG00000000005', 'ENSG00000000419',
       'ENSG00000000457', 'ENSG00000000460'],
      dtype='object')
False
Index(['TSPAN6', 'TNMD', 'DPM1', 'SCYL3', 'FIRRM'], dtype='object', name='gene_name')
```