### PR TITLE
Feature/hestbench flexibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ tests/assets
 config
 tests/output_tests
 HEST/
+*.pyc
 
 results
 atlas

--- a/bench_config/bench_config.yaml
+++ b/bench_config/bench_config.yaml
@@ -1,14 +1,14 @@
 # directory containing the data for each task
-bench_data_root: 'bench_data'
+bench_data_root: 'eval/bench_data'
 
 # directory where benchmark results will be dumped
-results_dir: 'ST_pred_results'
+results_dir: 'eval/ST_pred_results'
 
 # directory where the vision embeddings will be dumped
-embed_dataroot: 'ST_data_emb'
+embed_dataroot: 'eval/ST_data_emb'
 
 # directory to the model weights root
-weights_root: 'fm_v1'
+weights_root: 'eval/fm_v1'
 
 # inference parameters
 batch_size: 128

--- a/docs/source/api.md
+++ b/docs/source/api.md
@@ -24,7 +24,7 @@
 .. autosummary::
     :toctree: generated
    
-    benchmark_encoder
+    benchmark
 ```
 
 ## HESTData class

--- a/src/hest/bench/__init__.py
+++ b/src/hest/bench/__init__.py
@@ -1,2 +1,2 @@
 from . import st_dataset
-from .benchmark import benchmark_encoder
+from .benchmark import benchmark

--- a/src/hest/bench/cpath_model_zoo/inference_models.py
+++ b/src/hest/bench/cpath_model_zoo/inference_models.py
@@ -75,7 +75,7 @@ class CustomInferenceEncoder(InferenceEncoder):
     def __init__(self, weights_path, name, model, transforms, precision):
         super().__init__(weights_path)
         self.model = model
-        self.transforms = transforms
+        self.eval_transforms = transforms
         self.precision = precision
         
     def _build(self, weights_path):

--- a/tutorials/4-Running-HEST-Benchmark.ipynb
+++ b/tutorials/4-Running-HEST-Benchmark.ipynb
@@ -4,12 +4,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Step-by-step instructions to run HEST-Benchmark\n",
+    "<!-- ## Step-by-step instructions to run HEST-Benchmark\n",
     "\n",
     "This tutorial will guide you to:\n",
     "\n",
     "- **Reproduce** HEST-Benchmark results provided in the paper (Random Forest regression and Ridge regression models)\n",
-    "- Benchmark your **own** model\n"
+    "- Benchmark your **own** model -->\n"
    ]
   },
   {
@@ -30,7 +30,7 @@
     "| Task 6      | READ         | 4                     | Visium         | ZEN36, ZEN40, ZEN48, ZEN49      |\n",
     "| Task 7      | ccRCC        | 24                    | Visium         | INT1~INT24      |\n",
     "| Task 8      | HCC          | 2                     | Visium         | NCBI642, NCBI643      |\n",
-    "| Task 9      | LUAD         | 2                     | Xenium         | TENX118, TENX141      |\n",
+    "| Task 9      | LUNG         | 2                     | Xenium         | TENX118, TENX141      |\n",
     "| Task 10     | IDC-LymphNode | 4                    | Visium         | NCBI681, NCBI682, NCBI683, NCBI684     |\n",
     "\n"
    ]
@@ -102,7 +102,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from hest.bench import benchmark_encoder\n",
+    "from hest.bench import benchmark\n",
     "import torch\n",
     "\n",
     "PATH_TO_CONFIG = .. # path to `bench_config.yaml`\n",
@@ -110,11 +110,11 @@
     "model_transforms = .. # transforms to apply during inference (torchvision.transforms.Compose)\n",
     "precision = torch.float32\n",
     "\n",
-    "benchmark_encoder(        \n",
+    "benchmark(        \n",
     "    model, \n",
     "    model_transforms,\n",
     "    precision,\n",
-    "    PATH_TO_CONFIG\n",
+    "    config=PATH_TO_CONFIG, \n",
     ")"
    ]
   }


### PR DESCRIPTION
**This PR**
* Makes some changes to integrate HestBench more easily into an evaluation pipeline without being restricted to the CLI to run it
* Removes redundant `benchmark_eval` function (everything is in `benchmark`)
* Minor fix to `CustomInferenceEncoder` in the `inf_encoder_factory` 

**Run instructions** 
* Run HestBench evaluation as given in `tutorials/4-Running-HEST-Benchmark.ipynb`