### PR TITLE
fix: correct missing df argument in pool_transcripts_xenium pandas branch

### DIFF
--- a/src/hest/readers.py
+++ b/src/hest/readers.py
@@ -1190,7 +1190,8 @@ def pool_transcripts_xenium(
         spot_grid_np = h.astype(np.uint32).compute()
         
     else:
-        cols_c = get_indices_chunk(key_x, key_y, 
+        # pandas case: df is a single partition, pass directly
+        cols_c = get_indices_chunk(df, key_x, key_y, 
                       x_min, y_min, spot_size_um, pixel_size_he, n, spot_grid.columns)
 
         c = cols_c['c']

--- a/tests/hest_tests.py
+++ b/tests/hest_tests.py
@@ -4,9 +4,12 @@ import warnings
 from datetime import datetime
 from os.path import join as _j
 import zipfile
+import pandas as pd
+import dask.dataframe as dd
 
 from hest.path_utils import get_path_relative
 from hest.trident_compat import CucimWarningSingleton
+from hest.readers import pool_transcripts_xenium
 from huggingface_hub import snapshot_download
 from tqdm import tqdm
 
@@ -220,6 +223,41 @@ class TestHESTData(unittest.TestCase):
     #            st.meta['pixel_size_um_embedded'] = st.pixel_size / 1.5
     #            st.meta['pixel_size_um_estimated'] = st.pixel_size
     #            st.save(_j(self.output_dir, f'test_save_{idx}'), save_img=True, plot_pxl_size=True)
+
+class TestXenium(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(self):
+        self.df = pd.DataFrame({
+            'he_x': [3228.11, 3227.8, 3271.2], 
+            'he_y': [46903.1, 47103.0, 46892.5],
+            'feature_name': ["b'TCIM'", "b'RUNX1'", "b'SEC11C'"]
+            })
+
+    def test_pool_transcripts_xenium_pandas(self):
+        adata = pool_transcripts_xenium(
+            df=self.df,
+            pixel_size_he=0.21,
+            key_x='he_x',
+            key_y='he_y',
+            spot_size_um=200,
+        )
+        assert adata.n_obs > 0
+        assert adata.n_vars == 3
+
+    def test_pool_transcripts_xenium_dask(self):
+        df = dd.from_pandas(self.df, npartitions=2)
+        
+        adata = pool_transcripts_xenium(
+            df=df,
+            pixel_size_he=0.21,
+            key_x='he_x',
+            key_y='he_y',
+            spot_size_um=200,
+        )
+        
+        assert adata.n_obs > 0
+        assert adata.n_vars == 3
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #138.

Running pool_transcript_xenium doesn't work when the `st.transcript_df` is a `pandas` object, which is the default based on the comments in the tutorials/2-Interacting-with-HEST-1k.ipynb. The problem is the missing argument for `df` itself.

In this PR, I corrected the argument in the given branch for the function `get_indices_chunk()`. Additionally, I included unit tests for the function, covering both `dask` and `pandas` object paths.